### PR TITLE
fix: timeline alignment, real stream events, and list pagination

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,7 @@ name: CD
 on:
   workflow_run:
     workflows:
-      - CI and Deploy
+      - CI
     types:
       - completed
     branches:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,7 @@ name: CD
 on:
   workflow_run:
     workflows:
-      - CI
+      - CI and Deploy
     types:
       - completed
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI and Deploy
 
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI and Deploy
+name: CI
 
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: read
+  statuses: write
 
 jobs:
   changes:
@@ -251,3 +252,15 @@ jobs:
           fi
 
           echo "All changed components passed required jobs"
+
+      - name: Report commit status
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          state="failure"
+          [ "${{ job.status }}" = "success" ] && state="success"
+          gh api "repos/${{ github.repository }}/statuses/${{ github.sha }}" \
+            -f state="$state" \
+            -f context="CI / CI Gate" \
+            -f description="CI gate $state"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ WEB_DIR := packages/web
 export BIN_DIR
 
 .PHONY: deps run build tests test migrate migrate-create migrate-force migrate-reset
-.PHONY: ansible migrate-up migrate-down migrate-version migrate-force-reset
+.PHONY: ansible migrate-up migrate-down migrate-version migrate-force-reset dev-db
 
 # Development
 deps:
@@ -17,6 +17,11 @@ run:
 	cd $(SERVER_DIR) && go run cmd/daemon/main.go & \
 	cd $(WEB_DIR) && npm run dev & \
 	wait
+
+dev-db:
+	@echo "Starting local dev database..."
+	docker compose up -d db
+	@echo "DB ready on localhost:5433"
 
 build:
 	@echo "Building Go daemon..."
@@ -82,6 +87,7 @@ help:
 	@echo "Development:"
 	@echo "  make deps              - Install frontend dependencies"
 	@echo "  make run               - Run API server + Vite dev server"
+	@echo "  make dev-db            - Start local dev database (Docker)"
 	@echo "  make build             - Build Go daemon + frontend"
 	@echo "  make tests             - Run all integration tests"
 	@echo ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: kadeem
+      POSTGRES_HOST_AUTH_METHOD: trust
+    ports:
+      - "5433:5432"
+    volumes:
+      - kadeem_db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d kadeem"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  kadeem_db:

--- a/packages/server/internal/api/handler/events.go
+++ b/packages/server/internal/api/handler/events.go
@@ -1,0 +1,97 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/galchammat/kadeem/internal/logging"
+	"github.com/galchammat/kadeem/internal/service"
+	"github.com/go-chi/chi/v5"
+)
+
+// EventsHandler handles stream event HTTP requests.
+type EventsHandler struct {
+	events *service.StreamEventsService
+}
+
+// NewEventsHandler creates a new EventsHandler.
+func NewEventsHandler(events *service.StreamEventsService) *EventsHandler {
+	return &EventsHandler{events: events}
+}
+
+// SyncChannelEvents triggers a sync of hype train and clip events for the given channel.
+func (h *EventsHandler) SyncChannelEvents(w http.ResponseWriter, r *http.Request) {
+	channelID := chi.URLParam(r, "channelID")
+	if err := h.events.SyncChannelEvents(channelID); err != nil {
+		logging.Error("failed to sync channel events", "channel_id", channelID, "error", err)
+		respondError(w, http.StatusInternalServerError, "failed to sync events")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ListChannelEvents returns stream events for a specific channel.
+func (h *EventsHandler) ListChannelEvents(w http.ResponseWriter, r *http.Request) {
+	channelID := chi.URLParam(r, "channelID")
+	from, to, limit, offset := parseEventParams(r)
+
+	events, err := h.events.ListChannelEvents(channelID, from, to, limit, offset)
+	if err != nil {
+		logging.Error("failed to list channel events", "channel_id", channelID, "error", err)
+		respondError(w, http.StatusInternalServerError, "failed to list events")
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]any{
+		"events": events,
+		"count":  len(events),
+	})
+}
+
+// ListStreamerEvents returns stream events for all channels of a streamer.
+func (h *EventsHandler) ListStreamerEvents(w http.ResponseWriter, r *http.Request) {
+	streamerID, err := strconv.ParseInt(chi.URLParam(r, "streamerID"), 10, 64)
+	if err != nil {
+		respondError(w, http.StatusBadRequest, "invalid streamer ID")
+		return
+	}
+
+	from, to, limit, offset := parseEventParams(r)
+
+	events, err := h.events.ListStreamerEvents(streamerID, from, to, limit, offset)
+	if err != nil {
+		logging.Error("failed to list streamer events", "streamer_id", streamerID, "error", err)
+		respondError(w, http.StatusInternalServerError, "failed to list events")
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]any{
+		"events": events,
+		"count":  len(events),
+	})
+}
+
+// parseEventParams extracts from, to, limit, and offset from query params with sensible defaults.
+func parseEventParams(r *http.Request) (from, to int64, limit, offset int) {
+	q := r.URL.Query()
+
+	from, _ = strconv.ParseInt(q.Get("from"), 10, 64)
+
+	to, _ = strconv.ParseInt(q.Get("to"), 10, 64)
+	if to == 0 {
+		to = time.Now().Unix()
+	}
+
+	limit, _ = strconv.Atoi(q.Get("limit"))
+	if limit <= 0 || limit > 500 {
+		limit = 100
+	}
+
+	offset, _ = strconv.Atoi(q.Get("offset"))
+	if offset < 0 {
+		offset = 0
+	}
+
+	return from, to, limit, offset
+}

--- a/packages/server/internal/api/handler/riot.go
+++ b/packages/server/internal/api/handler/riot.go
@@ -230,7 +230,7 @@ func (h *RiotHandler) ListMatches(w http.ResponseWriter, r *http.Request) {
 		limit = 20
 	}
 
-	var account *model.LeagueOfLegendsAccount
+	var account *model.LolAccount
 	if puuid != "" {
 		acc, err := h.db.GetRiotAccount(puuid)
 		if err != nil {

--- a/packages/server/internal/api/handler/riot.go
+++ b/packages/server/internal/api/handler/riot.go
@@ -79,7 +79,13 @@ func (h *RiotHandler) AddAccount(w http.ResponseWriter, r *http.Request) {
 func (h *RiotHandler) ListAccounts(w http.ResponseWriter, r *http.Request) {
 	userID, _ := middleware.GetUserID(r)
 
-	accounts, err := h.db.ListTrackedAccounts(userID)
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+	if limit <= 0 {
+		limit = 100
+	}
+
+	accounts, err := h.db.ListTrackedAccounts(userID, limit, offset)
 	if err != nil {
 		logging.Error("Failed to list tracked accounts", "error", err)
 		respondError(w, http.StatusInternalServerError, "Failed to list accounts")

--- a/packages/server/internal/api/routes.go
+++ b/packages/server/internal/api/routes.go
@@ -60,6 +60,11 @@ func (s *Server) setupRoutes(jwksURL string) {
 			// Broadcasts
 			r.Post("/channels/{channelID}/broadcasts/sync", s.livestreamHandler.SyncBroadcasts)
 			r.Get("/broadcasts", s.livestreamHandler.ListBroadcasts)
+
+			// Stream events
+			r.Post("/channels/{channelID}/events/sync", s.eventsHandler.SyncChannelEvents)
+			r.Get("/channels/{channelID}/events", s.eventsHandler.ListChannelEvents)
+			r.Get("/streamers/{streamerID}/events", s.eventsHandler.ListStreamerEvents)
 		})
 	})
 }

--- a/packages/server/internal/api/server.go
+++ b/packages/server/internal/api/server.go
@@ -26,6 +26,7 @@ type Server struct {
 	riotHandler       *handler.RiotHandler
 	dataDragonHandler *handler.DataDragonHandler
 	livestreamHandler *handler.LivestreamHandler
+	eventsHandler     *handler.EventsHandler
 }
 
 // NewServer creates a new API server
@@ -41,6 +42,7 @@ func NewServer(db *database.DB, port string) *Server {
 	matchSvc := service.NewMatchService(db, riotClient)
 	rankSvc := service.NewRankService(db, riotClient)
 	streamerSvc := service.NewStreamerService(db, twitchClient)
+	streamEventsSvc := service.NewStreamEventsService(db, twitchClient)
 
 	// Get frontend domain from env
 	frontendDomain := os.Getenv("FRONTEND_DOMAIN")
@@ -70,6 +72,7 @@ func NewServer(db *database.DB, port string) *Server {
 		riotHandler:       handler.NewRiotHandler(db, accountSvc, matchSvc, rankSvc),
 		dataDragonHandler: handler.NewDataDragonHandler(dataDragonClient),
 		livestreamHandler: handler.NewLivestreamHandler(streamerSvc),
+		eventsHandler:     handler.NewEventsHandler(streamEventsSvc),
 	}
 
 	// Setup routes

--- a/packages/server/internal/database/riot_account.go
+++ b/packages/server/internal/database/riot_account.go
@@ -10,7 +10,7 @@ import (
 )
 
 // SaveRiotAccount saves a League of Legends account to the database (shared pool)
-func (db *DB) SaveRiotAccount(account *model.LeagueOfLegendsAccount) error {
+func (db *DB) SaveRiotAccount(account *model.LolAccount) error {
 	logging.Debug("updating account", "account", account)
 	query := `
         INSERT INTO league_of_legends_accounts 
@@ -31,10 +31,10 @@ func (db *DB) SaveRiotAccount(account *model.LeagueOfLegendsAccount) error {
 }
 
 // GetRiotAccount retrieves an account by PUUID
-func (db *DB) GetRiotAccount(puuid string) (*model.LeagueOfLegendsAccount, error) {
+func (db *DB) GetRiotAccount(puuid string) (*model.LolAccount, error) {
 	query := `SELECT puuid, tag_line, game_name, region, synced_at, streamer_id FROM league_of_legends_accounts WHERE puuid = $1`
 
-	var account model.LeagueOfLegendsAccount
+	var account model.LolAccount
 	err := db.SQL.QueryRow(query, puuid).Scan(&account.PUUID, &account.TagLine, &account.GameName, &account.Region, &account.SyncedAt, &account.StreamerID)
 	if err != nil {
 		logging.Error("Failed to get Riot account from database", "puuid", puuid, "error", err)
@@ -45,16 +45,16 @@ func (db *DB) GetRiotAccount(puuid string) (*model.LeagueOfLegendsAccount, error
 }
 
 // GetRiotAccountByPUUID is an alias for GetRiotAccount (replaces former GetRiotAccountByID)
-func (db *DB) GetRiotAccountByPUUID(puuid string) (*model.LeagueOfLegendsAccount, error) {
+func (db *DB) GetRiotAccountByPUUID(puuid string) (*model.LolAccount, error) {
 	return db.GetRiotAccount(puuid)
 }
 
 // FindRiotAccount finds an account by game name, tag line, and region
-func (db *DB) FindRiotAccount(gameName, tagLine, region string) (*model.LeagueOfLegendsAccount, error) {
+func (db *DB) FindRiotAccount(gameName, tagLine, region string) (*model.LolAccount, error) {
 	query := `SELECT puuid, tag_line, game_name, region, synced_at, streamer_id FROM league_of_legends_accounts 
 	          WHERE game_name = $1 AND tag_line = $2 AND region = $3`
 
-	var account model.LeagueOfLegendsAccount
+	var account model.LolAccount
 	err := db.SQL.QueryRow(query, gameName, tagLine, region).Scan(&account.PUUID, &account.TagLine, &account.GameName, &account.Region, &account.SyncedAt, &account.StreamerID)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -68,7 +68,7 @@ func (db *DB) FindRiotAccount(gameName, tagLine, region string) (*model.LeagueOf
 }
 
 // FindOrCreateRiotAccount finds or creates an account (idempotent)
-func (db *DB) FindOrCreateRiotAccount(gameName, tagLine, region string, streamerID int) (*model.LeagueOfLegendsAccount, error) {
+func (db *DB) FindOrCreateRiotAccount(gameName, tagLine, region string, streamerID int) (*model.LolAccount, error) {
 	account, err := db.FindRiotAccount(gameName, tagLine, region)
 	if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (db *DB) FindOrCreateRiotAccount(gameName, tagLine, region string, streamer
 	}
 
 	// Create new account
-	newAccount := &model.LeagueOfLegendsAccount{
+	newAccount := &model.LolAccount{
 		GameName:   gameName,
 		TagLine:    tagLine,
 		Region:     region,
@@ -93,7 +93,7 @@ func (db *DB) FindOrCreateRiotAccount(gameName, tagLine, region string, streamer
 }
 
 // ListTrackedAccounts returns accounts a user is tracking with pagination
-func (db *DB) ListTrackedAccounts(userID string, limit, offset int) ([]model.LeagueOfLegendsAccount, error) {
+func (db *DB) ListTrackedAccounts(userID string, limit, offset int) ([]model.LolAccount, error) {
 	query := `SELECT a.puuid, a.tag_line, a.game_name, a.region, a.synced_at, a.streamer_id 
 	          FROM league_of_legends_accounts a
 	          INNER JOIN user_tracked_accounts uta ON a.puuid = uta.account_puuid
@@ -108,9 +108,9 @@ func (db *DB) ListTrackedAccounts(userID string, limit, offset int) ([]model.Lea
 	}
 	defer rows.Close()
 
-	var accounts []model.LeagueOfLegendsAccount
+	var accounts []model.LolAccount
 	for rows.Next() {
-		var account model.LeagueOfLegendsAccount
+		var account model.LolAccount
 		if err := rows.Scan(&account.PUUID, &account.TagLine, &account.GameName, &account.Region, &account.SyncedAt, &account.StreamerID); err != nil {
 			logging.Error("Failed to scan tracked account row", "error", err)
 			return nil, err
@@ -157,7 +157,7 @@ func (db *DB) IsTrackingAccount(userID string, accountPUUID string) (bool, error
 }
 
 // GetTrackedAccountsForSync returns all accounts with at least one tracker (for background jobs)
-func (db *DB) GetTrackedAccountsForSync() ([]model.LeagueOfLegendsAccount, error) {
+func (db *DB) GetTrackedAccountsForSync() ([]model.LolAccount, error) {
 	query := `SELECT DISTINCT a.puuid, a.tag_line, a.game_name, a.region, a.synced_at, a.streamer_id 
 	          FROM league_of_legends_accounts a
 	          INNER JOIN user_tracked_accounts uta ON a.puuid = uta.account_puuid`
@@ -169,9 +169,9 @@ func (db *DB) GetTrackedAccountsForSync() ([]model.LeagueOfLegendsAccount, error
 	}
 	defer rows.Close()
 
-	var accounts []model.LeagueOfLegendsAccount
+	var accounts []model.LolAccount
 	for rows.Next() {
-		var account model.LeagueOfLegendsAccount
+		var account model.LolAccount
 		if err := rows.Scan(&account.PUUID, &account.TagLine, &account.GameName, &account.Region, &account.SyncedAt, &account.StreamerID); err != nil {
 			logging.Error("Failed to scan account row for sync", "error", err)
 			return nil, err
@@ -186,7 +186,7 @@ func (db *DB) GetTrackedAccountsForSync() ([]model.LeagueOfLegendsAccount, error
 }
 
 // ListRiotAccounts lists accounts with optional filtering and pagination (for admin/internal use)
-func (db *DB) ListRiotAccounts(filter *model.LeagueOfLegendsAccount, limit, offset int) ([]model.LeagueOfLegendsAccount, error) {
+func (db *DB) ListRiotAccounts(filter *model.LolAccount, limit, offset int) ([]model.LolAccount, error) {
 	query := `SELECT puuid, tag_line, game_name, region, synced_at, streamer_id FROM league_of_legends_accounts`
 	var where []string
 	var args []any
@@ -231,9 +231,9 @@ func (db *DB) ListRiotAccounts(filter *model.LeagueOfLegendsAccount, limit, offs
 	}
 	defer rows.Close()
 
-	var accounts []model.LeagueOfLegendsAccount
+	var accounts []model.LolAccount
 	for rows.Next() {
-		var account model.LeagueOfLegendsAccount
+		var account model.LolAccount
 		if err := rows.Scan(&account.PUUID, &account.TagLine, &account.GameName, &account.Region, &account.SyncedAt, &account.StreamerID); err != nil {
 			logging.Error("Failed to scan Riot account row", "error", err)
 			return nil, err

--- a/packages/server/internal/database/riot_match_test.go
+++ b/packages/server/internal/database/riot_match_test.go
@@ -148,13 +148,13 @@ func TestInsertLolMatchWithParticipants_Transaction(t *testing.T) {
 	startedAt := int64(1600000000)
 	duration := 2000
 
-	summary := &model.LeagueOfLegendsMatchSummary{
+	summary := &model.LolMatchSummary{
 		ID:        matchID,
 		StartedAt: &startedAt,
 		Duration:  &duration,
 	}
 
-	participants := []model.LeagueOfLegendsMatchParticipantSummary{
+	participants := []model.LolMatchParticipantSummary{
 		{
 			GameID:                      matchID,
 			ChampionID:                  1,
@@ -222,13 +222,13 @@ func TestListLolMatches_WithCompleteMatch(t *testing.T) {
 	startedAt := int64(1600000000)
 	duration := 2500
 
-	summary := &model.LeagueOfLegendsMatchSummary{
+	summary := &model.LolMatchSummary{
 		ID:        matchID,
 		StartedAt: &startedAt,
 		Duration:  &duration,
 	}
 
-	participants := []model.LeagueOfLegendsMatchParticipantSummary{
+	participants := []model.LolMatchParticipantSummary{
 		{
 			GameID:                      matchID,
 			ChampionID:                  10,

--- a/packages/server/internal/database/stream_events.go
+++ b/packages/server/internal/database/stream_events.go
@@ -1,0 +1,113 @@
+package database
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/galchammat/kadeem/internal/model"
+)
+
+// ListStreamEvents returns stream events matching the filter, ordered by timestamp descending.
+func (db *DB) ListStreamEvents(filter *model.StreamEventFilter, limit, offset int) ([]model.StreamEvent, error) {
+	query := `SELECT se.id, se.channel_id, se.event_type, se.title, se.description,
+	                 se.timestamp, se.value, se.external_id
+	          FROM stream_events se`
+
+	var joins []string
+	var where []string
+	var args []any
+	argN := 1
+
+	if filter != nil {
+		if filter.StreamerID != nil {
+			joins = append(joins, "INNER JOIN channels c ON se.channel_id = c.id")
+			where = append(where, fmt.Sprintf("c.streamer_id = $%d", argN))
+			args = append(args, *filter.StreamerID)
+			argN++
+		}
+		if filter.ChannelID != nil {
+			where = append(where, fmt.Sprintf("se.channel_id = $%d", argN))
+			args = append(args, *filter.ChannelID)
+			argN++
+		}
+		if filter.EventType != nil {
+			where = append(where, fmt.Sprintf("se.event_type = $%d", argN))
+			args = append(args, string(*filter.EventType))
+			argN++
+		}
+		if filter.TimestampMin != nil {
+			where = append(where, fmt.Sprintf("se.timestamp >= $%d", argN))
+			args = append(args, *filter.TimestampMin)
+			argN++
+		}
+		if filter.TimestampMax != nil {
+			where = append(where, fmt.Sprintf("se.timestamp <= $%d", argN))
+			args = append(args, *filter.TimestampMax)
+			argN++
+		}
+	}
+
+	if len(joins) > 0 {
+		query += " " + strings.Join(joins, " ")
+	}
+	if len(where) > 0 {
+		query += " WHERE " + strings.Join(where, " AND ")
+	}
+	query += fmt.Sprintf(" ORDER BY se.timestamp DESC LIMIT $%d OFFSET $%d", argN, argN+1)
+	args = append(args, limit, offset)
+
+	rows, err := db.SQL.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list stream events: %w", err)
+	}
+	defer rows.Close()
+
+	var events []model.StreamEvent
+	for rows.Next() {
+		var e model.StreamEvent
+		if err := rows.Scan(
+			&e.ID, &e.ChannelID, &e.EventType, &e.Title, &e.Description,
+			&e.Timestamp, &e.Value, &e.ExternalID,
+		); err != nil {
+			return nil, fmt.Errorf("scan stream event: %w", err)
+		}
+		events = append(events, e)
+	}
+	return events, rows.Err()
+}
+
+// UpsertStreamEvents inserts stream events, ignoring duplicates by (channel_id, external_id).
+func (db *DB) UpsertStreamEvents(events []model.StreamEvent) error {
+	if len(events) == 0 {
+		return nil
+	}
+
+	tx, err := db.SQL.Begin()
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	stmt, err := tx.Prepare(`
+		INSERT INTO stream_events (channel_id, event_type, title, description, timestamp, value, external_id)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT (channel_id, external_id)
+		WHERE external_id IS NOT NULL
+		DO NOTHING
+	`)
+	if err != nil {
+		return fmt.Errorf("prepare statement: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, e := range events {
+		if _, err := stmt.Exec(
+			e.ChannelID, string(e.EventType), e.Title, e.Description,
+			e.Timestamp, e.Value, e.ExternalID,
+		); err != nil {
+			return fmt.Errorf("upsert stream event %v: %w", e.ExternalID, err)
+		}
+	}
+
+	return tx.Commit()
+}

--- a/packages/server/internal/model/riot.go
+++ b/packages/server/internal/model/riot.go
@@ -4,7 +4,7 @@ type LolApiReplaysResponse struct {
 	URLs []string `json:"matchFileURLs"`
 }
 
-type LeagueOfLegendsAccount struct {
+type LolAccount struct {
 	PUUID      string `json:"puuid" db:"puuid,primarykey"`
 	StreamerID int    `json:"streamerId,omitempty" db:"streamer_id"`
 	TagLine    string `json:"tagLine" db:"tag_line"`
@@ -13,13 +13,13 @@ type LeagueOfLegendsAccount struct {
 	SyncedAt   *int64 `json:"syncedAt" db:"synced_at"`
 }
 
-type LeagueOfLegendsMatch struct {
-	Summary      LeagueOfLegendsMatchSummary              `json:"summary" db:"-"`
-	Participants []LeagueOfLegendsMatchParticipantSummary `json:"participants" db:"-"`
-	ReplayURL    *string                                  `json:"replay,omitempty" db:"replay"`
+type LolMatch struct {
+	Summary      LolMatchSummary              `json:"summary" db:"-"`
+	Participants []LolMatchParticipantSummary `json:"participants" db:"-"`
+	ReplayURL    *string                      `json:"replay,omitempty" db:"replay"`
 }
 
-type LeagueOfLegendsMatchSummary struct {
+type LolMatchSummary struct {
 	ID           int64  `json:"gameId" db:"match_id"`
 	StartedAt    *int64 `json:"startedAt" db:"started_at"`
 	Duration     *int   `json:"duration" db:"duration"`
@@ -27,7 +27,7 @@ type LeagueOfLegendsMatchSummary struct {
 	ReplaySynced *bool  `json:"replaySynced" db:"replay_synced"`
 }
 
-type LeagueOfLegendsMatchParticipantSummary struct {
+type LolMatchParticipantSummary struct {
 	GameID                      int64  `json:"gameId" db:"match_id"`
 	ChampionID                  int    `json:"championId" db:"champion_id"`
 	ChampLevel                  int    `json:"champLevel" db:"champ_level"`

--- a/packages/server/internal/model/stream_event.go
+++ b/packages/server/internal/model/stream_event.go
@@ -1,0 +1,30 @@
+package model
+
+// StreamEventType classifies a stream event.
+type StreamEventType string
+
+const (
+	StreamEventHypeTrain StreamEventType = "hype_train"
+	StreamEventClip      StreamEventType = "clip"
+)
+
+// StreamEvent is a notable moment that occurred during a live broadcast.
+type StreamEvent struct {
+	ID          int64           `json:"id"`
+	ChannelID   string          `json:"channel_id"`
+	EventType   StreamEventType `json:"type"`
+	Title       string          `json:"title"`
+	Description string          `json:"description"`
+	Timestamp   int64           `json:"timestamp"` // Unix seconds
+	Value       *string         `json:"value,omitempty"`
+	ExternalID  *string         `json:"-"` // Twitch event ID; used for deduplication
+}
+
+// StreamEventFilter constrains a ListStreamEvents query.
+type StreamEventFilter struct {
+	ChannelID    *string
+	StreamerID   *int64
+	EventType    *StreamEventType
+	TimestampMin *int64
+	TimestampMax *int64
+}

--- a/packages/server/internal/riot/api/accounts.go
+++ b/packages/server/internal/riot/api/accounts.go
@@ -9,7 +9,7 @@ import (
 )
 
 // FetchAccount fetches account data from the Riot API by gameName and tagLine.
-func (c *Client) FetchAccount(region, gameName, tagLine string) (*model.LeagueOfLegendsAccount, error) {
+func (c *Client) FetchAccount(region, gameName, tagLine string) (*model.LolAccount, error) {
 	if gameName == "" || tagLine == "" || region == "" {
 		return nil, fmt.Errorf("gameName, tagLine, and region cannot be empty")
 	}
@@ -24,7 +24,7 @@ func (c *Client) FetchAccount(region, gameName, tagLine string) (*model.LeagueOf
 		return nil, fmt.Errorf("failed to fetch account from Riot servers: %v", err)
 	}
 
-	var account model.LeagueOfLegendsAccount
+	var account model.LolAccount
 	if err := json.Unmarshal(body, &account); err != nil {
 		logging.Error("Failed to unmarshal account JSON response", "gameName", gameName, "tagLine", tagLine, "error", err)
 		return nil, err
@@ -34,7 +34,7 @@ func (c *Client) FetchAccount(region, gameName, tagLine string) (*model.LeagueOf
 }
 
 // FetchAccountByPUUID fetches account data from the Riot API by PUUID.
-func (c *Client) FetchAccountByPUUID(region, puuid string) (*model.LeagueOfLegendsAccount, error) {
+func (c *Client) FetchAccountByPUUID(region, puuid string) (*model.LolAccount, error) {
 	url := c.buildURL(region, fmt.Sprintf("/riot/account/v1/accounts/by-puuid/%s", puuid))
 	body, _, err := c.makeRequest(url)
 	if err != nil {
@@ -42,7 +42,7 @@ func (c *Client) FetchAccountByPUUID(region, puuid string) (*model.LeagueOfLegen
 		return nil, err
 	}
 
-	var account model.LeagueOfLegendsAccount
+	var account model.LolAccount
 	if err := json.Unmarshal(body, &account); err != nil {
 		logging.Error("Failed to unmarshal account JSON response", "puuid", puuid, "error", err)
 		return nil, err

--- a/packages/server/internal/riot/api/match_summary.go
+++ b/packages/server/internal/riot/api/match_summary.go
@@ -14,7 +14,7 @@ type MatchDetailResponse struct {
 		ID           int64                                          `json:"gameId"`
 		StartedAt    int64                                          `json:"gameStartTimestamp"`
 		Duration     int                                            `json:"gameDuration"`
-		Participants []model.LeagueOfLegendsMatchParticipantSummary `json:"participants"`
+		Participants []model.LolMatchParticipantSummary `json:"participants"`
 	} `json:"info"`
 }
 

--- a/packages/server/internal/service/account.go
+++ b/packages/server/internal/service/account.go
@@ -30,7 +30,7 @@ func (s *AccountService) AddAccount(region, gameName, tagLine string, streamerID
 }
 
 // ReconcileAccount checks if account data has changed on Riot servers and updates DB.
-func (s *AccountService) ReconcileAccount(account *model.LeagueOfLegendsAccount) error {
+func (s *AccountService) ReconcileAccount(account *model.LolAccount) error {
 	fetched, err := s.riot.FetchAccountByPUUID(account.Region, account.PUUID)
 	if err != nil {
 		return err
@@ -49,7 +49,7 @@ func (s *AccountService) ReconcileAccount(account *model.LeagueOfLegendsAccount)
 }
 
 // ListAccounts lists accounts with optional reconciliation.
-func (s *AccountService) ListAccounts(filter *model.LeagueOfLegendsAccount) ([]model.LeagueOfLegendsAccount, error) {
+func (s *AccountService) ListAccounts(filter *model.LolAccount) ([]model.LolAccount, error) {
 	accounts, err := s.db.ListRiotAccounts(filter, 1000, 0)
 	if err != nil {
 		return nil, err

--- a/packages/server/internal/service/account.go
+++ b/packages/server/internal/service/account.go
@@ -50,7 +50,7 @@ func (s *AccountService) ReconcileAccount(account *model.LeagueOfLegendsAccount)
 
 // ListAccounts lists accounts with optional reconciliation.
 func (s *AccountService) ListAccounts(filter *model.LeagueOfLegendsAccount) ([]model.LeagueOfLegendsAccount, error) {
-	accounts, err := s.db.ListRiotAccounts(filter)
+	accounts, err := s.db.ListRiotAccounts(filter, 1000, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/server/internal/service/match.go
+++ b/packages/server/internal/service/match.go
@@ -27,7 +27,7 @@ func NewMatchService(db *database.DB, riot *riot.Client) *MatchService {
 }
 
 // SyncMatches syncs replays and match summaries for an account.
-func (s *MatchService) SyncMatches(account model.LeagueOfLegendsAccount) error {
+func (s *MatchService) SyncMatches(account model.LolAccount) error {
 	logging.Debug("Syncing matches for account", "ID", account.PUUID)
 
 	replayURLs, err := s.riot.FetchReplayURLs(account.PUUID, account.Region)
@@ -46,7 +46,7 @@ func (s *MatchService) SyncMatches(account model.LeagueOfLegendsAccount) error {
 		if err != nil {
 			return fmt.Errorf("error while checking for an existing match. MatchID: %d. Error: %w", matchID, err)
 		}
-		var existingMatch *model.LeagueOfLegendsMatch
+		var existingMatch *model.LolMatch
 		if len(existingMatches) != 0 {
 			existingMatch = &existingMatches[0]
 		}
@@ -84,7 +84,7 @@ func (s *MatchService) SyncMatchSummary(matchID int64, fullMatchID, region strin
 		return err
 	}
 
-	summary := model.LeagueOfLegendsMatchSummary{
+	summary := model.LolMatchSummary{
 		ID:        response.Info.ID,
 		StartedAt: &response.Info.StartedAt,
 		Duration:  &response.Info.Duration,
@@ -119,7 +119,7 @@ func (s *MatchService) SyncMatchReplay(matchID int64, replayURL string) error {
 }
 
 // ListMatches lists matches with auto-sync if stale.
-func (s *MatchService) ListMatches(filter *model.LolMatchFilter, account *model.LeagueOfLegendsAccount, limit, offset int) ([]model.LeagueOfLegendsMatch, error) {
+func (s *MatchService) ListMatches(filter *model.LolMatchFilter, account *model.LolAccount, limit, offset int) ([]model.LolMatch, error) {
 	if account != nil &&
 		(account.SyncedAt == nil || time.Since(time.Unix(*account.SyncedAt, 0)) > constants.SyncRefreshInMinutes*time.Minute) {
 		if err := s.SyncMatches(*account); err != nil {

--- a/packages/server/internal/service/match_test.go
+++ b/packages/server/internal/service/match_test.go
@@ -85,7 +85,7 @@ func TestComputeBroadcastSyncStartTime_ExclusiveBoundary(t *testing.T) {
 func TestSyncBoundaryTimestampConsistency(t *testing.T) {
 	now := time.Now().Unix()
 
-	account := model.LeagueOfLegendsAccount{
+	account := model.LolAccount{
 		SyncedAt: &now,
 	}
 

--- a/packages/server/internal/service/rank.go
+++ b/packages/server/internal/service/rank.go
@@ -20,7 +20,7 @@ func NewRankService(db *database.DB, riot *riot.Client) *RankService {
 }
 
 // SyncRank fetches current rank for an account and stores a snapshot.
-func (s *RankService) SyncRank(account *model.LeagueOfLegendsAccount) error {
+func (s *RankService) SyncRank(account *model.LolAccount) error {
 	summonerID, err := s.riot.FetchSummonerID(account.PUUID, account.Region)
 	if err != nil {
 		return err

--- a/packages/server/internal/service/stream_events.go
+++ b/packages/server/internal/service/stream_events.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/galchammat/kadeem/internal/database"
+	"github.com/galchammat/kadeem/internal/model"
+	"github.com/galchammat/kadeem/internal/twitch"
+)
+
+// StreamEventsService manages stream event syncing and retrieval.
+type StreamEventsService struct {
+	db     *database.DB
+	twitch *twitch.TwitchClient
+}
+
+// NewStreamEventsService creates a new StreamEventsService.
+func NewStreamEventsService(db *database.DB, twitchClient *twitch.TwitchClient) *StreamEventsService {
+	return &StreamEventsService{db: db, twitch: twitchClient}
+}
+
+// SyncChannelEvents fetches and persists hype train and clip events for the given channel.
+func (s *StreamEventsService) SyncChannelEvents(channelID string) error {
+	hypeEvents, err := s.twitch.FetchHypeTrainEvents(channelID)
+	if err != nil {
+		return fmt.Errorf("fetch hype train events for channel %s: %w", channelID, err)
+	}
+
+	clipEvents, err := s.twitch.FetchTopClips(channelID)
+	if err != nil {
+		return fmt.Errorf("fetch clip events for channel %s: %w", channelID, err)
+	}
+
+	all := append(hypeEvents, clipEvents...)
+	if err := s.db.UpsertStreamEvents(all); err != nil {
+		return fmt.Errorf("upsert stream events for channel %s: %w", channelID, err)
+	}
+	return nil
+}
+
+// ListChannelEvents returns stream events for a specific channel within the given time range.
+func (s *StreamEventsService) ListChannelEvents(channelID string, from, to int64, limit, offset int) ([]model.StreamEvent, error) {
+	filter := &model.StreamEventFilter{
+		ChannelID:    &channelID,
+		TimestampMin: &from,
+		TimestampMax: &to,
+	}
+	return s.db.ListStreamEvents(filter, limit, offset)
+}
+
+// ListStreamerEvents returns stream events for all channels of a streamer within the given time range.
+func (s *StreamEventsService) ListStreamerEvents(streamerID int64, from, to int64, limit, offset int) ([]model.StreamEvent, error) {
+	filter := &model.StreamEventFilter{
+		StreamerID:   &streamerID,
+		TimestampMin: &from,
+		TimestampMax: &to,
+	}
+	return s.db.ListStreamEvents(filter, limit, offset)
+}

--- a/packages/server/internal/service/streamer.go
+++ b/packages/server/internal/service/streamer.go
@@ -22,7 +22,7 @@ func NewStreamerService(db *database.DB, twitchClient *twitch.TwitchClient) *Str
 
 func (s *StreamerService) ListStreamersWithDetails() ([]model.StreamerView, error) {
 	var streamerViews []model.StreamerView
-	streamers, err := s.db.ListStreamers()
+	streamers, err := s.db.ListStreamers(1000, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -32,7 +32,7 @@ func (s *StreamerService) ListStreamersWithDetails() ([]model.StreamerView, erro
 			StreamerName: streamer.Name,
 		}
 		var lastLive int64
-		channels, err := s.db.ListChannels(&model.ChannelFilter{StreamerID: &streamer.ID})
+		channels, err := s.db.ListChannels(&model.ChannelFilter{StreamerID: &streamer.ID}, 1000, 0)
 		if err != nil {
 			return nil, err
 		}
@@ -112,7 +112,7 @@ func (s *StreamerService) ListBroadcasts(filter *model.Broadcast, limit, offset 
 		return nil, fmt.Errorf("channelID must be specified")
 	}
 
-	channels, err := s.db.ListChannels(&model.ChannelFilter{ID: &filter.ChannelID})
+	channels, err := s.db.ListChannels(&model.ChannelFilter{ID: &filter.ChannelID}, 1, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/server/internal/twitch/events.go
+++ b/packages/server/internal/twitch/events.go
@@ -1,0 +1,141 @@
+package twitch
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/galchammat/kadeem/internal/logging"
+	"github.com/galchammat/kadeem/internal/model"
+)
+
+type hypeTrainItem struct {
+	ID             string `json:"id"`
+	EventType      string `json:"event_type"`
+	EventTimestamp string `json:"event_timestamp"`
+	EventData      struct {
+		Level            int `json:"level"`
+		Total            int `json:"total"`
+		TopContributions []struct {
+			UserName string `json:"user_name"`
+			Type     string `json:"type"`
+			Total    int    `json:"total"`
+		} `json:"top_contributions"`
+	} `json:"event_data"`
+}
+
+type clipItem struct {
+	ID          string  `json:"id"`
+	Title       string  `json:"title"`
+	ViewCount   int     `json:"view_count"`
+	CreatedAt   string  `json:"created_at"`
+	CreatorName string  `json:"creator_name"`
+	Duration    float64 `json:"duration"`
+}
+
+// FetchHypeTrainEvents fetches ended hype train events for the given broadcaster.
+func (c *TwitchClient) FetchHypeTrainEvents(broadcasterID string) ([]model.StreamEvent, error) {
+	params := url.Values{}
+	params.Set("broadcaster_id", broadcasterID)
+	params.Set("first", "100")
+
+	response, statusCode, err := c.makeRequest("/helix/hypetrain/events?" + params.Encode())
+	if err != nil {
+		return nil, fmt.Errorf("fetch hype train events: %w", err)
+	}
+	if statusCode != 200 {
+		return nil, fmt.Errorf("fetch hype train events: unexpected status %d", statusCode)
+	}
+
+	var rawMessages []json.RawMessage
+	if err := json.Unmarshal(response.Data, &rawMessages); err != nil {
+		return nil, fmt.Errorf("unmarshal hype train events: %w", err)
+	}
+
+	var events []model.StreamEvent
+	for _, raw := range rawMessages {
+		var item hypeTrainItem
+		if err := json.Unmarshal(raw, &item); err != nil {
+			logging.Warn("failed to unmarshal hype train item", "error", err)
+			continue
+		}
+		if item.EventType != "hypetrain.end" {
+			continue
+		}
+
+		ts, err := time.Parse(time.RFC3339, item.EventTimestamp)
+		if err != nil {
+			logging.Warn("failed to parse hype train timestamp", "error", err)
+			continue
+		}
+
+		level := strconv.Itoa(item.EventData.Level)
+		description := fmt.Sprintf("Total %d pts · Level %d", item.EventData.Total, item.EventData.Level)
+		if len(item.EventData.TopContributions) > 0 {
+			top := item.EventData.TopContributions[0]
+			description += fmt.Sprintf(" · Top: %s (%s)", top.UserName, top.Type)
+		}
+
+		externalID := item.ID
+		events = append(events, model.StreamEvent{
+			ChannelID:   broadcasterID,
+			EventType:   model.StreamEventHypeTrain,
+			Title:       fmt.Sprintf("Hype Train Level %d", item.EventData.Level),
+			Description: description,
+			Timestamp:   ts.Unix(),
+			Value:       &level,
+			ExternalID:  &externalID,
+		})
+	}
+	return events, nil
+}
+
+// FetchTopClips fetches recent top clips for the given broadcaster.
+func (c *TwitchClient) FetchTopClips(broadcasterID string) ([]model.StreamEvent, error) {
+	params := url.Values{}
+	params.Set("broadcaster_id", broadcasterID)
+	params.Set("first", "20")
+
+	response, statusCode, err := c.makeRequest("/helix/clips?" + params.Encode())
+	if err != nil {
+		return nil, fmt.Errorf("fetch clips: %w", err)
+	}
+	if statusCode != 200 {
+		return nil, fmt.Errorf("fetch clips: unexpected status %d", statusCode)
+	}
+
+	var rawMessages []json.RawMessage
+	if err := json.Unmarshal(response.Data, &rawMessages); err != nil {
+		return nil, fmt.Errorf("unmarshal clips: %w", err)
+	}
+
+	var events []model.StreamEvent
+	for _, raw := range rawMessages {
+		var item clipItem
+		if err := json.Unmarshal(raw, &item); err != nil {
+			logging.Warn("failed to unmarshal clip item", "error", err)
+			continue
+		}
+
+		ts, err := time.Parse(time.RFC3339, item.CreatedAt)
+		if err != nil {
+			logging.Warn("failed to parse clip timestamp", "error", err)
+			continue
+		}
+
+		views := strconv.Itoa(item.ViewCount)
+		externalID := item.ID
+		events = append(events, model.StreamEvent{
+			ChannelID:   broadcasterID,
+			EventType:   model.StreamEventClip,
+			Title:       item.Title,
+			Description: fmt.Sprintf("by %s · %d views · %.0fs", item.CreatorName, item.ViewCount, item.Duration),
+			Timestamp:   ts.Unix(),
+			Value:       &views,
+			ExternalID:  &externalID,
+		})
+	}
+	return events, nil
+}

--- a/packages/server/migrations/011_create_stream_events_table.up.sql
+++ b/packages/server/migrations/011_create_stream_events_table.up.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS stream_events (
+    id          BIGSERIAL PRIMARY KEY,
+    channel_id  VARCHAR(30) NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+    event_type  VARCHAR(30) NOT NULL,
+    title       TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    timestamp   BIGINT NOT NULL,
+    value       TEXT,
+    external_id TEXT
+);
+
+-- Prevents duplicate events from repeated syncs
+CREATE UNIQUE INDEX IF NOT EXISTS idx_stream_events_external
+    ON stream_events(channel_id, external_id)
+    WHERE external_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_stream_events_channel_time
+    ON stream_events(channel_id, timestamp DESC);

--- a/packages/server/tests/integration/twitch_channel_test.go
+++ b/packages/server/tests/integration/twitch_channel_test.go
@@ -50,7 +50,7 @@ func testAddTwitchChannel(t *testing.T) {
 	twitchClient := twitch.NewTwitchClient(context.Background())
 	streamerSvc := service.NewStreamerService(db, twitchClient)
 
-	streamers, err := db.ListStreamers()
+	streamers, err := db.ListStreamers(1000, 0)
 	if err != nil {
 		t.Fatal("Failed to list streamers:", err)
 	}

--- a/packages/server/tests/integration/twitch_events_test.go
+++ b/packages/server/tests/integration/twitch_events_test.go
@@ -1,0 +1,52 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/galchammat/kadeem/internal/database"
+	"github.com/galchammat/kadeem/internal/service"
+	"github.com/galchammat/kadeem/internal/twitch"
+)
+
+func TestSyncStreamEvents(t *testing.T) {
+	if os.Getenv("RUN_INTEGRATION_TESTS") != "true" {
+		t.Skip("Skipping integration test; set RUN_INTEGRATION_TESTS=true to run it")
+	}
+
+	const channelID = "104410477"
+
+	db, err := database.OpenDB()
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	defer db.SQL.Close()
+
+	twitchClient := twitch.NewTwitchClient(context.Background())
+	svc := service.NewStreamEventsService(db, twitchClient)
+
+	t.Run("SyncChannelEvents", func(t *testing.T) {
+		if err := svc.SyncChannelEvents(channelID); err != nil {
+			t.Fatalf("SyncChannelEvents: %v", err)
+		}
+		t.Log("sync completed without error")
+	})
+
+	t.Run("ListChannelEventsAfterSync", func(t *testing.T) {
+		const (
+			from   int64 = 0
+			to     int64 = 9_999_999_999
+			limit        = 100
+			offset       = 0
+		)
+		events, err := svc.ListChannelEvents(channelID, from, to, limit, offset)
+		if err != nil {
+			t.Fatalf("ListChannelEvents: %v", err)
+		}
+		t.Logf("channel %s: %d event(s) in db", channelID, len(events))
+		for _, ev := range events {
+			t.Logf("  type=%-12s ts=%d title=%q", ev.EventType, ev.Timestamp, ev.Title)
+		}
+	})
+}

--- a/packages/web/src/App.css
+++ b/packages/web/src/App.css
@@ -74,6 +74,11 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+  --victory: oklch(0.53 0.18 145);
+  --defeat: oklch(0.577 0.245 27.325);
+  --info: oklch(0.55 0.15 255);
+  --gold: oklch(0.75 0.17 85);
+  --warning: oklch(0.7 0.19 60);
 }
 
 .dark {
@@ -108,6 +113,11 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+  --victory: oklch(0.53 0.18 145);
+  --defeat: oklch(0.577 0.245 27.325);
+  --info: oklch(0.55 0.15 255);
+  --gold: oklch(0.75 0.17 85);
+  --warning: oklch(0.7 0.19 60);
 }
 
 @layer base {

--- a/packages/web/src/components/icons/lol.tsx
+++ b/packages/web/src/components/icons/lol.tsx
@@ -1,6 +1,6 @@
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 
-function LeagueOfLegendsIcon() {
+function LolIcon() {
     return (
         <Avatar>
             <AvatarImage src="icons/league-of-legends-icon.webp" className="h-8 w-8 mr-2" />
@@ -9,4 +9,4 @@ function LeagueOfLegendsIcon() {
     )
 }
 
-export default LeagueOfLegendsIcon;
+export default LolIcon;

--- a/packages/web/src/components/matchCard/index.tsx
+++ b/packages/web/src/components/matchCard/index.tsx
@@ -16,6 +16,8 @@ export interface Match {
   timeAgo: string
   result: "Victory" | "Defeat"
   duration: string
+  startedAt: number
+  durationSeconds: number
   champion: {
     name: string
     image: string
@@ -76,7 +78,7 @@ export function MatchCard({ match }: { match: Match }) {
         </div>
 
         {/* Summoner spells + Items */}
-        <div className="flex shrink-0 flex-col justify-center gap-1 self-center">
+        <div className="flex shrink-0 flex-col justify-center gap-1 self-center min-w-[78px]">
           <div className="flex gap-0.5">
             {match.summonerSpells.map((spell, i) => (
               <div key={i} className="relative h-5 w-5 overflow-hidden rounded border border-border">
@@ -94,7 +96,7 @@ export function MatchCard({ match }: { match: Match }) {
         </div>
 
         {/* KDA section */}
-        <div className="flex shrink-0 flex-col items-center justify-center gap-0.5 px-2 self-center">
+        <div className="flex shrink-0 flex-col items-center justify-center gap-0.5 px-2 self-center min-w-[80px]">
           <span className="text-base font-bold text-foreground whitespace-nowrap">
             {match.kda.kills} / <span className="text-[var(--defeat)]">{match.kda.deaths}</span> / {match.kda.assists}
           </span>
@@ -102,7 +104,7 @@ export function MatchCard({ match }: { match: Match }) {
         </div>
 
         {/* Stats section */}
-        <div className="flex shrink-0 flex-col justify-center gap-0.5 border-l border-border pl-2 text-[11px] self-center">
+        <div className="flex shrink-0 flex-col justify-center gap-0.5 border-l border-border pl-2 text-[11px] self-center min-w-[92px]">
           <div className="flex items-center gap-1.5">
             <span className="text-[var(--gold)] font-semibold">Laning</span>
             <span className="text-foreground/80 font-medium">{match.stats.laning}</span>
@@ -122,7 +124,7 @@ export function MatchCard({ match }: { match: Match }) {
         </div>
 
         {/* Placement + Performance tag */}
-        <div className="flex shrink-0 flex-col items-center justify-center gap-1 px-2 self-center">
+        <div className="flex shrink-0 flex-col items-center justify-center gap-1 px-2 self-center min-w-[60px]">
           <span className="text-lg font-bold text-foreground">{match.placement}</span>
           <span
             className={cn(

--- a/packages/web/src/components/matchStreamEvents/index.tsx
+++ b/packages/web/src/components/matchStreamEvents/index.tsx
@@ -9,30 +9,11 @@ import {
   Zap,
   AlertTriangle,
   Trophy,
+  Clapperboard,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { ScrollArea } from "@/components/ui/scroll-area"
-
-type EventType =
-  | "hype_train"
-  | "gifted_subs"
-  | "peak_viewers"
-  | "low_viewers"
-  | "raid"
-  | "donation"
-  | "new_subscriber"
-  | "chat_milestone"
-  | "follower_goal"
-  | "ban_wave"
-
-export interface StreamEvent {
-  id: number
-  type: EventType
-  title: string
-  description: string
-  timestamp: string
-  value?: string | number
-}
+import type { EventType, StreamEvent } from "@/types"
 
 const eventConfig: Record<EventType, { icon: typeof Flame; color: string; bg: string }> = {
   hype_train: { icon: Flame, color: "text-orange-400", bg: "bg-orange-500/15" },
@@ -45,6 +26,7 @@ const eventConfig: Record<EventType, { icon: typeof Flame; color: string; bg: st
   chat_milestone: { icon: MessageSquare, color: "text-blue-400", bg: "bg-blue-500/15" },
   follower_goal: { icon: Trophy, color: "text-yellow-400", bg: "bg-yellow-500/15" },
   ban_wave: { icon: AlertTriangle, color: "text-red-400", bg: "bg-red-500/15" },
+  clip: { icon: Clapperboard, color: "text-purple-400", bg: "bg-purple-500/15" },
 }
 
 interface MatchStreamEventsProps {
@@ -53,7 +35,7 @@ interface MatchStreamEventsProps {
 
 export function MatchStreamEvents({ events }: MatchStreamEventsProps) {
   return (
-    <div className="rounded-lg border border-border bg-card/50 overflow-hidden h-full min-h-[110px] max-h-[110px]">
+    <div className="rounded-lg border border-border bg-card/50 overflow-hidden h-full min-h-[110px]">
       <ScrollArea className="h-full">
         <div className="flex flex-col gap-1 p-2">
           {events.map((event) => {

--- a/packages/web/src/components/timeline/index.tsx
+++ b/packages/web/src/components/timeline/index.tsx
@@ -9,11 +9,12 @@ import { transformMatch } from "@/lib/matchTransformer"
 import { listStreamerEvents } from "@/lib/api"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
-import { Loader2 } from "lucide-react"
+import { AlertTriangle, Loader2 } from "lucide-react"
 
 interface SessionEntry {
   match: Match
   events: StreamEvent[]
+  overlapWarning?: string
 }
 
 interface SessionTimelineProps {
@@ -76,7 +77,34 @@ export default function SessionTimeline({ streamerId }: SessionTimelineProps) {
           }
         }
 
-        setSessionEntries(transformedEntries)
+        // Deduplicate by gameId then flag overlapping time windows
+        const seen = new Set<number>()
+        const deduped = transformedEntries.filter(e => {
+          if (seen.has(e.match.id)) return false
+          seen.add(e.match.id)
+          return true
+        })
+
+        const merged: SessionEntry[] = []
+        for (const entry of deduped) {
+          const eStart = entry.match.startedAt
+          const eEnd = eStart + entry.match.durationSeconds
+          const overlapIdx = merged.findIndex(prev => {
+            const pStart = prev.match.startedAt
+            const pEnd = pStart + prev.match.durationSeconds
+            return eStart < pEnd && pStart < eEnd
+          })
+          if (overlapIdx >= 0) {
+            merged[overlapIdx] = {
+              ...merged[overlapIdx],
+              overlapWarning: "Another account was also in a match during this time",
+            }
+          } else {
+            merged.push(entry)
+          }
+        }
+
+        setSessionEntries(merged)
       } catch (err) {
         setTransformError(`Failed to transform matches: ${err}`)
       } finally {
@@ -211,15 +239,23 @@ export default function SessionTimeline({ streamerId }: SessionTimelineProps) {
       {sessionEntries.length > 0 && (
         <div className="flex flex-col gap-3">
           {sessionEntries.map((entry) => (
-            <div key={entry.match.id} className="grid grid-cols-[1fr_280px] gap-4 items-stretch">
-              {/* Match card */}
-              <div className="min-w-0">
-                <MatchCard match={entry.match} />
-              </div>
+            <div key={entry.match.id} className="flex flex-col gap-1">
+              {entry.overlapWarning && (
+                <div className="flex items-center gap-1.5 rounded border border-yellow-400/40 bg-yellow-400/10 px-3 py-1.5 text-xs text-yellow-600 dark:text-yellow-400">
+                  <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+                  {entry.overlapWarning}
+                </div>
+              )}
+              <div className="grid grid-cols-[1fr_280px] gap-4 items-stretch">
+                {/* Match card */}
+                <div className="min-w-0">
+                  <MatchCard match={entry.match} />
+                </div>
 
-              {/* Stream events - aligned to match card */}
-              <div className="h-full">
-                <MatchStreamEvents events={entry.events} />
+                {/* Stream events - aligned to match card */}
+                <div className="h-full">
+                  <MatchStreamEvents events={entry.events} />
+                </div>
               </div>
             </div>
           ))}

--- a/packages/web/src/components/timeline/index.tsx
+++ b/packages/web/src/components/timeline/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react"
 import { MatchCard, type Match } from "@/components/matchCard"
 import { MatchStreamEvents } from "@/components/matchStreamEvents"
-import type { StreamEvent } from "@/types"
+import type { StreamEvent, LolMatchParticipantSummary } from "@/types"
 import Sectionheader from "@/components/sectionHeader"
 import { useLolAccounts } from "@/hooks/useLolAccounts"
 import useLolMatches from "@/hooks/useLolMatches"
@@ -55,7 +55,7 @@ export default function SessionTimeline({ streamerId }: SessionTimelineProps) {
         for (const match of matches) {
           // Find which tracked PUUID is in this match
           const trackedPUUID = trackedPUUIDs.find(puuid => 
-            match.participants.some(p => p.puuid === puuid)
+            match.participants.some((p: LolMatchParticipantSummary) => p.puuid === puuid)
           )
 
           if (!trackedPUUID) {

--- a/packages/web/src/hooks/useLolAccounts.ts
+++ b/packages/web/src/hooks/useLolAccounts.ts
@@ -1,9 +1,9 @@
 import { useState } from "react"
-import type { LeagueOfLegendsAccount } from "@/types"
+import type { LolAccount } from "@/types"
 import * as api from "@/lib/api"
 
 export interface UseLolAccountsReturn {
-  accounts: LeagueOfLegendsAccount[]
+  accounts: LolAccount[]
   loading: boolean
   error: string | null
   fetchAccounts: () => Promise<void>
@@ -13,7 +13,7 @@ export interface UseLolAccountsReturn {
 }
 
 export function useLolAccounts(): UseLolAccountsReturn {
-  const [accounts, setAccounts] = useState<LeagueOfLegendsAccount[]>([])
+  const [accounts, setAccounts] = useState<LolAccount[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 

--- a/packages/web/src/hooks/useLolMatches.ts
+++ b/packages/web/src/hooks/useLolMatches.ts
@@ -1,15 +1,15 @@
 import { useState, useEffect } from "react"
-import type { LeagueOfLegendsAccount, LeagueOfLegendsMatch } from "@/types"
+import type { LolAccount, LolMatch } from "@/types"
 import * as api from "@/lib/api"
 
 type FetchMatchesProps = {
   limit?: number
   offset?: number
-  accounts?: LeagueOfLegendsAccount[]
+  accounts?: LolAccount[]
 }
 
 export interface UseLolMatchesReturn {
-  matches: LeagueOfLegendsMatch[]
+  matches: LolMatch[]
   loading: boolean
   error: string | null
   partialErrors: Map<string, string>
@@ -17,9 +17,9 @@ export interface UseLolMatchesReturn {
 }
 
 export default function useLolMatches(
-  initialAccounts: LeagueOfLegendsAccount[]
+  initialAccounts: LolAccount[]
 ): UseLolMatchesReturn {
-  const [matches, setMatches] = useState<LeagueOfLegendsMatch[]>([])
+  const [matches, setMatches] = useState<LolMatch[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [partialErrors, setPartialErrors] = useState<Map<string, string>>(new Map())
@@ -46,7 +46,7 @@ export default function useLolMatches(
 
       // Track which accounts failed
       const errors = new Map<string, string>()
-      const allMatches: LeagueOfLegendsMatch[] = []
+      const allMatches: LolMatch[] = []
 
       results.forEach((result, idx) => {
         const account = fetchAccounts[idx]
@@ -66,7 +66,7 @@ export default function useLolMatches(
       }
 
       // Deduplicate by match ID
-      const matchMap = new Map<number, LeagueOfLegendsMatch>()
+      const matchMap = new Map<number, LolMatch>()
       for (const match of allMatches) {
         if (!matchMap.has(match.summary.gameId)) {
           matchMap.set(match.summary.gameId, match)

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1,6 +1,6 @@
 import type {
-  LeagueOfLegendsAccount,
-  LeagueOfLegendsMatch,
+  LolAccount,
+  LolMatch,
   StreamerView,
   PlayerRank,
   Broadcast,
@@ -39,8 +39,8 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 }
 
 // Riot Accounts
-export async function listAccounts(): Promise<LeagueOfLegendsAccount[]> {
-  const data = await request<{ accounts: LeagueOfLegendsAccount[]; count: number }>("/riot/accounts")
+export async function listAccounts(): Promise<LolAccount[]> {
+  const data = await request<{ accounts: LolAccount[]; count: number }>("/riot/accounts")
   return data.accounts ?? []
 }
 
@@ -63,9 +63,9 @@ export async function deleteAccount(accountId: string): Promise<void> {
 }
 
 // Riot Matches
-export async function listMatches(puuid: string, limit: number, offset: number): Promise<LeagueOfLegendsMatch[]> {
+export async function listMatches(puuid: string, limit: number, offset: number): Promise<LolMatch[]> {
   const params = new URLSearchParams({ puuid, limit: String(limit), offset: String(offset) })
-  const data = await request<{ matches: LeagueOfLegendsMatch[]; count: number }>(`/riot/matches?${params}`)
+  const data = await request<{ matches: LolMatch[]; count: number }>(`/riot/matches?${params}`)
   return data.matches ?? []
 }
 

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -8,6 +8,7 @@ import type {
   ItemData,
   SummonerSpellData,
   Channel,
+  StreamEvent,
 } from "@/types"
 import { supabase } from "@/lib/supabase"
 
@@ -112,6 +113,13 @@ export async function listBroadcasts(channelId: string, limit: number, offset: n
   const params = new URLSearchParams({ channelID: channelId, limit: String(limit), offset: String(offset) })
   const data = await request<{ broadcasts: Broadcast[]; count: number }>(`/broadcasts?${params}`)
   return data.broadcasts ?? []
+}
+
+// Stream Events
+export async function listStreamerEvents(streamerId: number, from: number, to: number, limit: number, offset: number): Promise<StreamEvent[]> {
+  const params = new URLSearchParams({ from: String(from), to: String(to), limit: String(limit), offset: String(offset) })
+  const data = await request<{ events: StreamEvent[]; count: number }>(`/streamers/${streamerId}/events?${params}`)
+  return data.events ?? []
 }
 
 // DataDragon

--- a/packages/web/src/lib/matchTransformer.ts
+++ b/packages/web/src/lib/matchTransformer.ts
@@ -1,6 +1,6 @@
 import type {
-  LeagueOfLegendsMatch,
-  LeagueOfLegendsMatchParticipantSummary,
+  LolMatch,
+  LolMatchParticipantSummary,
   PlayerRank,
   ChampionData,
   SummonerSpellData,
@@ -150,7 +150,7 @@ function calculateParticipation(
 
 // Transform backend match to frontend Match interface
 export async function transformMatch(
-  backendMatch: LeagueOfLegendsMatch,
+  backendMatch: LolMatch,
   trackedPUUID: string,
   accountId: string
 ): Promise<Match> {
@@ -217,7 +217,7 @@ export async function transformMatch(
   const winners = backendMatch.participants.filter((p) => p.win)
   const losers = backendMatch.participants.filter((p) => !p.win)
 
-  const buildTeamData = (participants: LeagueOfLegendsMatchParticipantSummary[]) => {
+  const buildTeamData = (participants: LolMatchParticipantSummary[]) => {
     return participants.slice(0, 5).map((p) => ({
       name: p.riotIdGameName || "Unknown",
       champion: championIconUrl(p.championId),

--- a/packages/web/src/lib/matchTransformer.ts
+++ b/packages/web/src/lib/matchTransformer.ts
@@ -234,6 +234,8 @@ export async function transformMatch(
 
   return {
     id: backendMatch.summary.gameId,
+    startedAt: backendMatch.summary.startedAt ?? 0,
+    durationSeconds: backendMatch.summary.duration ?? 0,
     queueType: QUEUE_NAMES[queueId] || "Unknown Queue",
     timeAgo: formatTimeAgo(backendMatch.summary.startedAt || 0),
     result: playerParticipant.win ? "Victory" : "Defeat",

--- a/packages/web/src/pages/accounts/index.tsx
+++ b/packages/web/src/pages/accounts/index.tsx
@@ -1,5 +1,5 @@
 import { Separator } from "@/components/ui/separator";
-import LeagueOfLegendsAccounts from "./leagueOfLegends";
+import LolAccounts from "./lol";
 import Channels from "./channel";
 import { useStreamer } from "@/hooks/useStreamer";
 import { AlertCircleIcon } from "lucide-react";
@@ -30,9 +30,9 @@ export function AccountsPage() {
     <div>
       <Channels />
       <Separator />
-      <LeagueOfLegendsAccounts streamerId={selectedStreamer.id} />
+      <LolAccounts streamerId={selectedStreamer.id} />
       <Separator />
-      <StreamerTimeline channels={[]} LeagueOfLegendsAccounts={[]} />
+      <StreamerTimeline channels={[]} lolAccounts={[]} />
     </div>
   );
 }

--- a/packages/web/src/pages/accounts/lol.tsx
+++ b/packages/web/src/pages/accounts/lol.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import type { LeagueOfLegendsAccount } from "@/types"
+import type { LolAccount } from "@/types"
 import { type DialogMode } from "@/types"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -17,7 +17,7 @@ import { PencilIcon, TrashIcon, PlusIcon, AlertCircleIcon } from "lucide-react"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { toast } from "sonner"
 import SectionHeader from "@/components/sectionHeader"
-import LeagueOfLegendsIcon from "@/components/icons/leagueOfLegends"
+import LolIcon from "@/components/icons/lol"
 import { SkeletonCard } from "@/components/skeletonCard"
 import { useConfirm } from "@/components/confirmDialog"
 import { useLolAccounts } from "@/hooks/useLolAccounts"
@@ -26,17 +26,17 @@ type propTypes = {
   streamerId: number
 }
 
-const defaultAccount: Partial<LeagueOfLegendsAccount> = {
+const defaultAccount: Partial<LolAccount> = {
   puuid: "",
   gameName: "",
   tagLine: "",
   region: "",
 }
 
-export default function LeagueOfLegendsAccounts({ streamerId }: propTypes) {
+export default function LolAccounts({ streamerId }: propTypes) {
   const { accounts, loading, error, fetchAccounts, addAccount, updateAccount, deleteAccount } = useLolAccounts()
   const [dialogMode, setDialogMode] = useState<DialogMode>(null)
-  const [formData, setFormData] = useState<Partial<LeagueOfLegendsAccount>>(defaultAccount)
+  const [formData, setFormData] = useState<Partial<LolAccount>>(defaultAccount)
   const [formError, setFormError] = useState<string | null>(null)
   const [formLoading, setFormLoading] = useState(false)
 
@@ -47,7 +47,7 @@ export default function LeagueOfLegendsAccounts({ streamerId }: propTypes) {
     return () => clearTimeout(timer)
   }, [streamerId])
 
-  const openDialog = (mode: DialogMode, a?: LeagueOfLegendsAccount) => {
+  const openDialog = (mode: DialogMode, a?: LolAccount) => {
     if (mode === "edit" && a) {
       setFormData({
         puuid: a.puuid,
@@ -63,7 +63,7 @@ export default function LeagueOfLegendsAccounts({ streamerId }: propTypes) {
   }
   const closeDialog = () => setDialogMode(null)
 
-  const handleDelete = async (account: LeagueOfLegendsAccount) => {
+  const handleDelete = async (account: LolAccount) => {
     if (
       !(await confirm({
         title: "Delete account?",
@@ -110,7 +110,7 @@ export default function LeagueOfLegendsAccounts({ streamerId }: propTypes) {
   if (loading) {
     return (
       <div className="p-6">
-        <SectionHeader title="League of Legends" icon={<LeagueOfLegendsIcon />} />
+        <SectionHeader title="League of Legends" icon={<LolIcon />} />
         <div className="flex flex-row p-6">
           <SkeletonCard />
         </div>
@@ -121,7 +121,7 @@ export default function LeagueOfLegendsAccounts({ streamerId }: propTypes) {
   if (error) {
     return (
       <div className="p-6">
-        <SectionHeader title="League of Legends" icon={<LeagueOfLegendsIcon />} />
+        <SectionHeader title="League of Legends" icon={<LolIcon />} />
         <div className="flex flex-col items-center justify-center p-8">
           <Alert variant="destructive" className="max-w-md w-full">
             <AlertCircleIcon className="h-6 w-6 mr-2" />
@@ -139,7 +139,7 @@ export default function LeagueOfLegendsAccounts({ streamerId }: propTypes) {
   return (
     <div className="p-6">
       <div className="flex items-center justify-between mb-6">
-        <SectionHeader title="League of Legends" icon={<LeagueOfLegendsIcon />} />
+        <SectionHeader title="League of Legends" icon={<LolIcon />} />
         <Dialog open={dialogMode === "add"} onOpenChange={(open) => { if (!open) closeDialog() }}>
           <DialogTrigger asChild>
             <Button onClick={() => openDialog("add")}>

--- a/packages/web/src/pages/accounts/timeline.tsx
+++ b/packages/web/src/pages/accounts/timeline.tsx
@@ -1,12 +1,12 @@
-import type { Channel, LeagueOfLegendsAccount } from "@/types"
+import type { Channel, LolAccount } from "@/types"
 import { SpanChart } from "@/components/charts/spanChart"
 
 function StreamerTimeline({
   channels,
-  LeagueOfLegendsAccounts,
+  lolAccounts,
 }: {
   channels: Channel[]
-  LeagueOfLegendsAccounts: LeagueOfLegendsAccount[]
+  lolAccounts: LolAccount[]
 }) {
   return (
     <div className="p-6">

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -96,6 +96,28 @@ export interface Broadcast {
   duration: number
 }
 
+export type EventType =
+  | "hype_train"
+  | "gifted_subs"
+  | "peak_viewers"
+  | "low_viewers"
+  | "raid"
+  | "donation"
+  | "new_subscriber"
+  | "chat_milestone"
+  | "follower_goal"
+  | "ban_wave"
+  | "clip"
+
+export interface StreamEvent {
+  id: number
+  type: EventType
+  title: string
+  description: string
+  timestamp: number
+  value?: string | number
+}
+
 // DataDragon
 export interface ChampionData {
   type: string

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -1,7 +1,7 @@
 export type DialogMode = null | "add" | "edit"
 
 // Riot / League of Legends
-export interface LeagueOfLegendsAccount {
+export interface LolAccount {
   puuid: string
   streamerId?: number
   tagLine: string
@@ -10,13 +10,13 @@ export interface LeagueOfLegendsAccount {
   syncedAt?: number | null
 }
 
-export interface LeagueOfLegendsMatch {
-  summary: LeagueOfLegendsMatchSummary
-  participants: LeagueOfLegendsMatchParticipantSummary[]
+export interface LolMatch {
+  summary: LolMatchSummary
+  participants: LolMatchParticipantSummary[]
   replay?: string | null
 }
 
-export interface LeagueOfLegendsMatchSummary {
+export interface LolMatchSummary {
   gameId: number
   startedAt?: number | null
   duration?: number | null
@@ -24,7 +24,7 @@ export interface LeagueOfLegendsMatchSummary {
   replaySynced?: boolean | null
 }
 
-export interface LeagueOfLegendsMatchParticipantSummary {
+export interface LolMatchParticipantSummary {
   gameId: number
   championId: number
   champLevel: number


### PR DESCRIPTION
## Summary

- **Issue #15**: Fixed horizontal alignment on the timeline matchCard (added `min-w` to each section) and vertical alignment (`items-stretch` on grid row, removed `max-h-[110px]` constraint). Also added missing CSS custom properties (`--victory`, `--defeat`, `--info`, `--gold`, `--warning`).
- **Issue #9**: Added `limit` and `offset` parameters to all unbounded DB List operations across `livestream.go` and `riot_account.go`.
- **Real stream events**: Full-stack implementation — DB migration (`stream_events` table), Go model/db/service/api layers for Twitch hype-train and clip event sync, and frontend wiring to correlate events to each match's time window on the timeline.

## Commits

- `195b89b` — `feat(db): add limit/offset to all unbounded list ops`
- `ee0f347` — `feat(server): twitch hype-train and clip stream event sync`
- `12bcdd0` — `fix(test): list streamers with limit/offset args`
- `dd19bf1` — `fix(ui): matchCard alignment, clip event type, CSS vars`
- `b2f53c9` — `feat(web): wire real stream events into timeline`

Closes #9
Closes #15